### PR TITLE
Fix team layout when jumping to section via fragment id

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2978,7 +2978,8 @@ font-weight: 300;
 }
 
 #text-15.widget.widget_text {
-padding-top: 60px;
+padding-top: 95px;
+margin-top: -35px;
 }
 
 #text-15:hover a {


### PR DESCRIPTION
**Issue**
#17 

**Problem**
Clicking the "Team" link jumps to the team section, but the nav bar cuts off the "our team" section

**Work Done**
Adjust padding/margin so that nav bar does not block any part of the Team header

**Before**

![teambug](https://user-images.githubusercontent.com/7697924/34316620-504bae18-e768-11e7-937b-2af98046c8cc.gif)

**After**

![teamfix](https://user-images.githubusercontent.com/7697924/34316618-4ad86976-e768-11e7-9ffe-a9d3d4258543.gif)
 
cc @jrgarou @felipegaucho @jellegerbrandy this is a pretty minor bug, but someone I know went to look up paratii and saw this issue and felt that the site was broken.